### PR TITLE
ci(github-actions): add frontend CI/CD pipeline for admin deployment (Story C.3)

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -1,0 +1,63 @@
+name: Deploy Admin Frontend
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-admin
+  cancel-in-progress: false  # 排队等待，确保每次部署完整执行，避免 SCP 传输途中被取消
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9  # 固定大版本，避免 breaking major 升级导致 lockfile 格式不兼容
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+        env:
+          VITE_APP_ENV: prod
+
+      - name: Validate build output
+        run: |
+          test -f dist/index.html || (echo "ERROR: dist/index.html not found, build output may be empty" && exit 1)
+          echo "Build output validated: dist/index.html exists"
+
+      - name: Deploy dist via SCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "dist/"
+          target: ${{ vars.FRONTEND_DEPLOY_PATH }}
+          strip_components: 1
+
+      - name: Reload Nginx and verify deploy
+        if: ${{ vars.NGINX_RELOAD_CMD != '' }}
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            ${{ vars.NGINX_RELOAD_CMD }}
+            echo "Nginx reloaded"
+            test -f "${{ vars.FRONTEND_DEPLOY_PATH }}/index.html" && echo "Deploy verified: index.html exists" || (echo "ERROR: index.html not found after deploy" && exit 1)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-admin.yml` to automate frontend build and deployment on push to `main`
- Triggers: push to `main` branch (PR merge = push to main on GitHub)
- Build: `pnpm install --frozen-lockfile` → `pnpm run build` (vue-tsc type-check + vite build)
- Deploy: SCP `dist/` to BT Panel nginx web root via `appleboy/scp-action@v0.1.7` (`strip_components: 1`)
- Optional nginx reload via SSH if `vars.NGINX_RELOAD_CMD` is configured

## Configuration Required

**Secrets** (Settings → Secrets and variables → Actions → Secrets):
| Name | Description |
|------|-------------|
| `SERVER_HOST` | Server IP / hostname (shared with C.2) |
| `SERVER_USER` | SSH login username (shared with C.2) |
| `SSH_PRIVATE_KEY` | SSH private key (shared with C.2) |

**Repository Variables** (Settings → Secrets and variables → Actions → Variables):
| Name | Required | Example |
|------|----------|---------|
| `FRONTEND_DEPLOY_PATH` | Required | `/www/wwwroot/pms-admin/` |
| `NGINX_RELOAD_CMD` | Optional | `/etc/init.d/nginx reload` |

## Design Decisions

- `concurrency.cancel-in-progress: false` — queues new deploys instead of cancelling mid-SCP to prevent partial uploads
- `pnpm version: 9` — pinned to avoid breaking lockfile format changes on major upgrades
- Pre-SCP validation step checks `dist/index.html` exists before transferring to server
- Verify step uses `test -f` with quoted path to handle spaces in `FRONTEND_DEPLOY_PATH`

## Test Plan

- [ ] Configure Secrets and Variables in `DogDaysStudio/union-admin` repo settings
- [ ] Merge this PR → verify GitHub Actions workflow triggers
- [ ] Confirm `dist/` contents appear at `FRONTEND_DEPLOY_PATH` on server
- [ ] Confirm site loads correctly in browser after deploy
- [ ] (Optional) Set `NGINX_RELOAD_CMD` and verify nginx reload step executes

Closes <!-- no linked issue -->

🤖 Story C.3 — Frontend CI/CD Pipeline